### PR TITLE
Cross-Account Access Fixes

### DIFF
--- a/backend/lib/central/data-domain-management.ts
+++ b/backend/lib/central/data-domain-management.ts
@@ -15,6 +15,7 @@ export interface DataDomainManagementProps {
     httpApi: HttpApi
     httpiApiUserPoolAuthorizer: HttpUserPoolAuthorizer
     centralEventBusArn: string
+    adjustGlueResourcePolicyFunction: Function
 }
 
 export class DataDomainManagement extends Construct {
@@ -76,7 +77,16 @@ export class DataDomainManagement extends Construct {
                             "arn:aws:iam::*:role/data-domain-*-accessRole",
                             crossAccountEbRole.roleArn
                         ]
-                    })
+                    }),
+                    new PolicyStatement({
+                        effect: Effect.ALLOW,
+                        actions: [
+                            "lambda:InvokeFunction"
+                        ],
+                        resources: [
+                            props.adjustGlueResourcePolicyFunction.functionArn
+                        ]
+                    }),
                 ]
             })}
         });
@@ -103,7 +113,8 @@ export class DataDomainManagement extends Construct {
                 DEFAULT_CONFIDENTIALITY: tbacConfig.DefaultValues[tbacConfig.TagKeys.Confidentiality],
                 CENTRAL_EVENT_BUS_ARN: props.centralEventBusArn,
                 LAMBDA_EXEC_ROLE_ARN: registerDataDomainRole.roleArn,
-                EB_XACCOUNT_ROLE_ARN: crossAccountEbRole.roleArn
+                EB_XACCOUNT_ROLE_ARN: crossAccountEbRole.roleArn,
+                ADJUST_RESOURCE_POLICY_FUNC_NAME: props.adjustGlueResourcePolicyFunction.functionName
             }
         })
 

--- a/backend/lib/central/resources/lambda/GetCrawlerState/index.js
+++ b/backend/lib/central/resources/lambda/GetCrawlerState/index.js
@@ -48,12 +48,10 @@ exports.handler = async(event) => {
                 error: (Item.error) ? Item.error.S : null
             })
         } catch (e) {
-            if (e instanceof ResourceNotFoundException) {
-                payload.statusCode = 404
-                payload.body = JSON.stringify({
-                    "error": "Resource not found"
-                })
-            }
+            payload.statusCode = 404
+            payload.body = JSON.stringify({
+                "error": "Resource not found"
+            })
         }
 
         return payload

--- a/backend/lib/central/resources/lambda/RegisterDataDomain/index.js
+++ b/backend/lib/central/resources/lambda/RegisterDataDomain/index.js
@@ -89,6 +89,14 @@ exports.handler = async(event) => {
 
     domainName = DomainName
 
+    const lambdaClient = new AWS.Lambda()
+    await lambdaClient.invoke({
+        FunctionName: process.env.ADJUST_RESOURCE_POLICY_FUNC_NAME,
+        Payload: JSON.stringify({
+            "accountId": domainId
+        })
+    }).promise()
+
     const validationCheck = await Promise.allSettled([
         glueClient.getDatabase({Name: `${LF_MODE_NRAC}-${DOMAIN_DATABASE_PREFIX}-${domainId}`}).promise(),
         glueClient.getDatabase({Name: `${LF_MODE_TBAC}-${DOMAIN_DATABASE_PREFIX}-${domainId}`}).promise()

--- a/backend/lib/central/tbac-sharing-workflow.ts
+++ b/backend/lib/central/tbac-sharing-workflow.ts
@@ -19,7 +19,8 @@ export interface TbacSharingWorkflowProps {
 export class TbacSharingWorkflow extends Construct {
 
     readonly lfTagGrantPermissionsRole: Role
-    readonly tbacSharingWorkflow: StateMachine;
+    readonly tbacSharingWorkflow: StateMachine
+    readonly adjustGlueResourcePolicyFunction: Function
 
     constructor(scope: Construct, id: string, props: TbacSharingWorkflowProps) {
         super(scope, id);
@@ -46,6 +47,8 @@ export class TbacSharingWorkflow extends Construct {
             role: adjustGlueResourcePolicyRole,
             code: Code.fromAsset(__dirname+"/resources/lambda/LFTagAdjustGlueResourcePolicy")
         });
+
+        this.adjustGlueResourcePolicyFunction = adjustGlueResourcePolicyFunction
 
         const checkApprovalRequirementRole = new Role(this, "CheckApprovalRequirementRole", {
             assumedBy: new ServicePrincipal("lambda.amazonaws.com"),

--- a/backend/lib/central/tbac-sharing-workflow.ts
+++ b/backend/lib/central/tbac-sharing-workflow.ts
@@ -154,7 +154,8 @@ export class TbacSharingWorkflow extends Construct {
                         "central_account_id": Stack.of(this).account,
                         "central_database_name.$": "$.databaseName",
                         "database_name": "tbac-data-domain",
-                        "lf_access_mode": "tbac"
+                        "lf_access_mode": "tbac",
+                        "producer_acc_id.$": "$.producerAccountId"
                       },
                       "DetailType.$": "States.Format('{}_createResourceLinks', $.targetAccountId)",
                       "EventBusName": centralEventBus.eventBusName,

--- a/backend/lib/datamesh-ui-central-stack.ts
+++ b/backend/lib/datamesh-ui-central-stack.ts
@@ -128,7 +128,8 @@ export class DataMeshUICentralStack extends Stack {
             uiAuthenticatedRole: dataMeshUIAuth.identityPool.authenticatedRole,
             httpApi: approvalWorkflow.httpApi,
             httpiApiUserPoolAuthorizer: dataMeshUIAuth.httpApiUserPoolAuthorizer,
-            centralEventBusArn: centralEventBusArn.valueAsString
+            centralEventBusArn: centralEventBusArn.valueAsString,
+            adjustGlueResourcePolicyFunction: tbacSharingWorkflow.adjustGlueResourcePolicyFunction
         })
     }
 }

--- a/backend/lib/producer/resources/lambda/ParseCrawlerStateChange/index.js
+++ b/backend/lib/producer/resources/lambda/ParseCrawlerStateChange/index.js
@@ -1,6 +1,9 @@
 const AWS = require("aws-sdk")
 const CRAWLER_NAME_REGEX = /.+?(tbac.+?|nrac.+?)_rl-(.+)/
 
+const NRAC_NAME_REGEX = /.+?(nrac.+?)_rl-(.+)/
+const TBAC_NAME_REGEX = /.+?rl-(tbac.+?)_(.+)/
+
 exports.handler = async({detail}) => {
     const {crawlerName, state, accountId} = detail
     let error = null;
@@ -9,8 +12,17 @@ exports.handler = async({detail}) => {
         error = detail.errorMessage
     }
 
-    const matchResults = CRAWLER_NAME_REGEX.exec(crawlerName)
-    const dbName = `${matchResults[1]}-${accountId}`
+    let matchResults = null
+    let dbName = null;
+
+    if (NRAC_NAME_REGEX.test(crawlerName)) {
+        matchResults = NRAC_NAME_REGEX.exec(crawlerName)
+        dbName = `${matchResults[1]}-${accountId}`
+    } else if (TBAC_NAME_REGEX.test(crawlerName)) {
+        matchResults = TBAC_NAME_REGEX.exec(crawlerName)
+        dbName = matchResults[1]
+    }
+
     const tableName = matchResults[2]
     const payload = {
         dbName: dbName,

--- a/src/Components/TBAC/DisplayLFTagsComponent.js
+++ b/src/Components/TBAC/DisplayLFTagsComponent.js
@@ -7,6 +7,7 @@ const cfnOutput = require("../../cfn-output.json");
 const tbacConfig = require("../../tbac-config.json");
 const config = Amplify.configure();
 const SM_ARN = cfnOutput.InfraStack.TbacStateMachineArn;
+const EXTRACT_PRODUCER_ACCOUNT_ID = /^.+?(\d{12})$/
 
 function DisplayLFTagsComponent(props) {
     const [modalVisible, setModalVisible] = useState(false);
@@ -29,13 +30,15 @@ function DisplayLFTagsComponent(props) {
         } else {
             // console.log("Tag Key: "+shareTagKey)
             // console.log("Tag Value: "+shareTagValue)
+            const producerAccountId = EXTRACT_PRODUCER_ACCOUNT_ID.exec(props.database)[1]
             const credentials = await Auth.currentCredentials();
             const sfnClient = new SFNClient({region: config.aws_project_region, credentials: Auth.essentialCredentials(credentials)});
 
             try {
-
+                
                 const params = {
-                    "targetAccountId": targetAccountId,
+                    producerAccountId,
+                    targetAccountId,
                     "databaseName": props.database,
                     "lfTags": [
                         {


### PR DESCRIPTION
Bug Fixes:

- Crawler status updates fails when registering TBAC products
- Data Domain registration now generates the right Glue resource policy
- Glue resource policy generation takes into account completely empty policy and generates hybrid policy that works for both NRAC and TBAC
- Sharing of tags now passes the producer account id